### PR TITLE
Call win_update_bounding_shape on size changes

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -794,11 +794,7 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation_running) {
 			// Submit window size change
 			if (size_changed) {
 				win_on_win_size_change(ps, w);
-
-				pixman_region32_clear(&w->bounding_shape);
-				pixman_region32_fini(&w->bounding_shape);
-				pixman_region32_init_rect(&w->bounding_shape, 0, 0,
-											(uint)w->widthb, (uint)w->heightb);
+				win_update_bounding_shape(ps, w);
 
 				if (w->state != WSTATE_DESTROYING)
 					win_clear_flags(w, WIN_FLAGS_PIXMAP_STALE);


### PR DESCRIPTION
This fixes issues where when different window shapes exist (rounded and non-rounded corner windows) in AwesomeWM, titlebars were not properly drawn when switching between tags (i.e.: non-rounded corners were displayed in windows that should have rounded corners).

<!-- Please enable "Allow edits from maintainers" so we can make necessary changes to your PR -->
